### PR TITLE
#3468 debugging notes

### DIFF
--- a/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
+++ b/core/jvm-native/src/main/scala/cats/effect/CallbackStack.scala
@@ -51,19 +51,23 @@ private final class CallbackStack[A](private[this] var callback: A => Unit)
   @tailrec
   def apply(oc: A, invoked: Boolean): Boolean = {
     val cb = callback
-
+    System.out.println(s"SRP callback apply 1: $cb, $oc, $invoked")
     val invoked2 = if (cb != null) {
       cb(oc)
+      System.out.println(s"SRP callback apply 1.5: $cb, $oc, $invoked")
       true
     } else {
       invoked
     }
 
     val next = get()
-    if (next != null)
+    if (next != null) {
+      System.out.println(s"SRP callback apply 1.75: $cb, $oc, $invoked")
       next(oc, invoked2)
-    else
+    } else {
+      System.out.println(s"SRP callback apply 2: $cb, $oc, $invoked2")
       invoked2
+    }
   }
 
   /**

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkStealingThreadPool.scala
@@ -510,17 +510,21 @@ private[effect] final class WorkStealingThreadPool(
    *   the runnable to be executed
    */
   override def execute(runnable: Runnable): Unit = {
+    println(s"SRP WSTP: inside execute")
     val pool = this
     val thread = Thread.currentThread()
 
     if (thread.isInstanceOf[WorkerThread]) {
       val worker = thread.asInstanceOf[WorkerThread]
       if (worker.isOwnedBy(pool)) {
+        println(s"SRP WSTP: schedule if worker owned by pool")
         worker.schedule(runnable)
       } else {
+        println(s"SRP WSTP: schedule external 1")
         scheduleExternal(runnable)
       }
     } else {
+      println(s"SRP WSTP: schedule external 2 ${thread.getName()}")
       scheduleExternal(runnable)
     }
   }

--- a/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
+++ b/core/jvm/src/main/scala/cats/effect/unsafe/WorkerThread.scala
@@ -416,7 +416,7 @@ private final class WorkerThread(
 
       ((state & ExternalQueueTicksMask): @switch) match {
         case 0 =>
-          println("SRP WT case 0")
+          println(s"SRP WT case 0 for thread ${self.index} ${self}")
           if (pool.blockedThreadDetectionEnabled) {
             // TODO prefetch pool.workerThread or Thread.State.BLOCKED ?
             // TODO check that branch elimination makes it free when off
@@ -484,7 +484,7 @@ private final class WorkerThread(
         case 1 =>
           // Check the external queue after a failed dequeue from the local
           // queue (due to the local queue being empty).
-          println("SRP WT case 1")
+          println(s"SRP WT case 1 for thread ${self.index} ${self}")
           val element = external.poll(rnd)
           if (element.isInstanceOf[Array[Runnable]]) {
             val batch = element.asInstanceOf[Array[Runnable]]
@@ -559,7 +559,7 @@ private final class WorkerThread(
           }
 
         case 2 =>
-          println("SRP WT case 2")
+          println(s"SRP WT case 2 for thread ${self.index} ${self}")
           // Try stealing fibers from other worker threads.
           val fiber = pool.stealFromOtherWorkerThread(index, rnd, self)
           if (fiber ne null) {
@@ -614,13 +614,13 @@ private final class WorkerThread(
         case 3 =>
           // Check the external queue after a failed dequeue from the local
           // queue (due to the local queue being empty).
-          println("SRP WT case 3")
+          println(s"SRP WT case 3 for thread ${self.index} ${self}")
           val element = external.poll(rnd)
           println(s"SRP WT case 3: found element $element")
+          println(s"SRP WT case 3 ${self.index} ${self}: element is array of runnable? ${element
+              .isInstanceOf[Array[Runnable]]}")
           println(
-            s"SRP WT case 3: element is array of runnable? ${element.isInstanceOf[Array[Runnable]]}")
-          println(
-            s"SRP WT case 3: element is single runnable? ${element.isInstanceOf[Runnable]}")
+            s"SRP WT case 3 ${self.index} ${self}: element is single runnable? ${element.isInstanceOf[Runnable]}")
 
           if (element.isInstanceOf[Array[Runnable]]) {
             val batch = element.asInstanceOf[Array[Runnable]]
@@ -657,6 +657,7 @@ private final class WorkerThread(
             pool.transitionWorkerFromSearching(rnd)
 
             // The dequeued element is a single fiber. Execute it immediately.
+            println(s"SRP WT case 3: about to run element ${self.index} ${self}")
             try fiber.run()
             catch {
               case t if NonFatal(t) =>
@@ -675,7 +676,7 @@ private final class WorkerThread(
           }
 
         case _ =>
-          println("SRP WT case _")
+          println(s"SRP WT case _ for thread ${self.index} ${self}")
           if (sleepers.nonEmpty) {
             val now = System.nanoTime()
 

--- a/core/shared/src/main/scala/cats/effect/IO.scala
+++ b/core/shared/src/main/scala/cats/effect/IO.scala
@@ -938,7 +938,10 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
    * should never be totally silent.
    */
   def unsafeRunAndForget()(implicit runtime: unsafe.IORuntime): Unit = {
-    val _ = unsafeRunFiber((), _ => (), _ => ())
+    println(
+      s"SRP unsafeRunAndForget: report unhandled errors? ${runtime.config.reportUnhandledFiberErrors}")
+    val _ =
+      unsafeRunFiber((), _ => (), _ => ())
     ()
   }
 
@@ -1014,6 +1017,7 @@ sealed abstract class IO[+A] private () extends IOPlatform[A] {
             canceled
           },
           { t =>
+            println(s"SRP unsafeRunFiber: inside failure outcome")
             runtime.fiberErrorCbs.remove(failure)
             failure(t)
           },

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -1016,17 +1016,20 @@ private final class IOFiber[A](
    */
   private[this] def done(oc: OutcomeIO[A]): Unit = {
     // println(s"<$name> invoking done($oc); callback = ${callback.get()}")
-    println("SRP fiber done")
+    System.out.println("SRP fiber done")
     _join = IO.pure(oc)
     _cancel = IO.unit
 
     outcome = oc
 
     try {
-      println(s"SRP outcome stack: ${oc}")
-      if (!callbacks(oc, false) && runtime.config.reportUnhandledFiberErrors) {
+      System.out.println(s"SRP outcome stack: ${oc}")
+      val x = callbacks(oc, false)
+      System.out.println(s"SRP callbacks: $x")
+      if (!x && runtime.config.reportUnhandledFiberErrors) {
         oc match {
-          case Outcome.Errored(e) => currentCtx.reportFailure(e)
+          case Outcome.Errored(e) =>
+            System.out.println(s"SRP oc match $oc"); currentCtx.reportFailure(e)
           case _ => ()
         }
       }

--- a/core/shared/src/main/scala/cats/effect/IOFiber.scala
+++ b/core/shared/src/main/scala/cats/effect/IOFiber.scala
@@ -113,6 +113,7 @@ private final class IOFiber[A](
 
   override def run(): Unit = {
     // insert a read barrier after every async boundary
+    println("SRP fiber run")
     readBarrier()
     (resumeTag: @switch) match {
       case 0 => execR()
@@ -1015,12 +1016,14 @@ private final class IOFiber[A](
    */
   private[this] def done(oc: OutcomeIO[A]): Unit = {
     // println(s"<$name> invoking done($oc); callback = ${callback.get()}")
+    println("SRP fiber done")
     _join = IO.pure(oc)
     _cancel = IO.unit
 
     outcome = oc
 
     try {
+      println(s"SRP outcome stack: ${oc}")
       if (!callbacks(oc, false) && runtime.config.reportUnhandledFiberErrors) {
         oc match {
           case Outcome.Errored(e) => currentCtx.reportFailure(e)


### PR DESCRIPTION
- #3468 
## Running
I've been testing with scala 3. I've been running this by:
- changing the version in build.sbt to `3.5-sam-SNAPSHOT`
- in sbt change the scala version to 3.2.2
- running `rootJVM/publishLocal` 
- using scala-cli to run Arman's example from the issue
```scala
//> using scala "3.2.2"
//> using lib "org.typelevel::cats-effect::3.5-sam-SNAPSHOT"

import cats.effect.*
import cats.effect.unsafe.implicits.*

@main def main =
  IO.raiseError(new RuntimeException).unsafeRunAndForget()
  Thread.sleep(1000)
```

## Notes
- added printlns all over the place
- tried to use them to follow my way down the worker thread
  - inside `run` on worker thread we end up in case 3: worker looking for work in external queue
    - in case 3 we find an element, which is a single runnable (vs. array of runnable)
    - the runnable is an IOFiber, and WT calls `fiber.run()`
- however the `try fiber.run()` DOES NOT cause me to see the println that I put in the fiber.run method
- also don't see anything coming out of fiber `done` method

<details><summary> println output </summary>

```
SRP WT case _
SRP WT case _
SRP WT case _
SRP WT case _
SRP WT case _
SRP WT case _
SRP WT case 1
SRP WT case _
SRP WT case _
SRP WT case _
SRP WT case _
SRP WT case _
SRP WT case _
SRP WT case 1
SRP WT case 1
SRP WT case 1
SRP WT case 1
SRP WT case 1
SRP WT case 2
SRP WT case 1
SRP WT case 1
SRP WT case 1
SRP WT case 1
SRP WT case 1
SRP WT case 2
SRP WT case 2
SRP WT case 2
SRP WT case 2
SRP WT case 2
SRP WT case 1
SRP WT case 2
SRP unsafeRunAndForget: report unhandled errors? true
SRP WSTP: inside execute
SRP WSTP: schedule external 2 main
SRP WT case 3
SRP WT case 3: found element cats.effect.IOFiber@354d4997 RUNNING
SRP WT case 3: element is array of runnable? false
SRP WT case 3: element is single runnable? true
SRP WT case 3: runnable element is fiber cats.effect.IOFiber@354d4997 RUNNING
SRP unsafeRunFiber: inside failure outcome
SRP WT case 3: after the fiber run call
SRP WT case _
SRP WT case 1
SRP WT case 2
```
</details>